### PR TITLE
Fixes Mwe2Launcher path glitch on Windows

### DIFF
--- a/org.example.model/pom.xml
+++ b/org.example.model/pom.xml
@@ -97,7 +97,7 @@
         <configuration>
           <mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
           <arguments>
-            <argument>${project.basedir}/src/main/java/GenerateModel.mwe2</argument>
+            <argument>file:///${project.basedir}/src/main/java/GenerateModel.mwe2</argument>
             <argument>-p</argument>
             <argument>rootPath=${project.basedir}/..</argument>
           </arguments>


### PR DESCRIPTION
Changes the argument hence making it recognized by `Mwe2Launcher` when running on Windows
`rootPath` needs no change since it's wrapped by `URI.createURI` later in `org.eclipse.emf.mwe.utils.StandaloneSetup`